### PR TITLE
Fixed minor build issue with new version of OSPRay.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,15 @@
 ## Copyright (c) 2016-2017 Ingo Wald
-## 
+##
 ## Permission is hereby granted, free of charge, to any person obtaining a copy
 ## of this software and associated documentation files (the "Software"), to deal
 ## in the Software without restriction, including without limitation the rights
 ## to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 ## copies of the Software, and to permit persons to whom the Software is
 ## furnished to do so, subject to the following conditions:
-## 
+##
 ## The above copyright notice and this permission notice shall be included in all
 ## copies or substantial portions of the Software.
-## 
+##
 ## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 ## IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 ## FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -18,17 +18,17 @@
 ## OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ## SOFTWARE.
 
-CONFIGURE_MPI()
+OSPRAY_CONFIGURE_MPI()
 
 # simple display-wall driver
 OPTION(OSPRAY_MODULE_DISPLAY_WALD "DisplayWald" ON)
 
 IF (OSPRAY_MODULE_DISPLAY_WALD)
-  
+
   SET(OSPRAY_DISPLAY_WALD_VERSION_MAJOR 0)
   SET(OSPRAY_DISPLAY_WALD_VERSION_MINOR 1)
   SET(OSPRAY_DISPLAY_WALD_VERSION_PATCH 0)
-  
+
   SET(OSPRAY_DISPLAY_WALD_VERSION
     ${OSPRAY_DISPLAY_WALD_VERSION_MAJOR}.${OSPRAY_DISPLAY_WALD_VERSION_MINOR}.${OSPRAY_DISPLAY_WALD_VERSION_PATCH})
 

--- a/ospray/CMakeLists.txt
+++ b/ospray/CMakeLists.txt
@@ -6,4 +6,5 @@ OSPRAY_ADD_LIBRARY(ospray_module_displayWald SHARED
 TARGET_LINK_LIBRARIES(ospray_module_displayWald
   ospray_displayWald_client
 	ospray
+  ospray_module_mpi
   )


### PR DESCRIPTION

OSPRay module was missing the library that implements mpicommon::worker.